### PR TITLE
Use float instead of np.float

### DIFF
--- a/temmeta/image_filters.py
+++ b/temmeta/image_filters.py
@@ -346,7 +346,7 @@ def _find_outliers(raw, percent=0.07, bins=(2**16)):
     """
     raw = np.array(raw)
     cnts, bin_edges = np.histogram(raw, bins=bins)
-    stats = np.zeros((2, bins), dtype=np.int)
+    stats = np.zeros((2, bins), dtype=int)
     # Calculate cumulative intensity distribution
     stats[0] = np.cumsum(cnts)  # low
     stats[1] = np.cumsum(cnts[::-1])  # high

--- a/temmeta/image_filters.py
+++ b/temmeta/image_filters.py
@@ -60,7 +60,7 @@ def normalize(arr):
     return linscale(arr)
 
 
-def linscale(arr, min=None, max=None, nmin=0, nmax=1, dtype=np.float):
+def linscale(arr, min=None, max=None, nmin=0, nmax=1, dtype=float):
     """
     Rescale image intensities
 
@@ -131,7 +131,7 @@ def _get_dtype_min_max(dtype):
 
     For floats it just returns 0 and 1
     """
-    if dtype == np.float or dtype == np.float32 or dtype == np.float64:
+    if dtype == float or dtype == np.float32 or dtype == np.float64:
         max = 1  # np.finfo(dtype).max
         min = 0  # np.finfo(dtype).min
     elif (dtype == np.int8 or dtype == np.uint8 or


### PR DESCRIPTION
np.float is a deprecated alias for float.

@din14970 If I remember correctly, you planned to convert TEMMETA to a hyperspy plugin or the like? Do you work on this package any longer?